### PR TITLE
Allow for deletion of selected text

### DIFF
--- a/resources/lostdj/lib/main.js
+++ b/resources/lostdj/lib/main.js
@@ -32,7 +32,7 @@ function pngmain()
 				newloc = cb;
 
 			ub.value = newloc;
-			
+
 			var evt = winutil.getFocusedWindow().document.createEvent("KeyEvents");
 			evt.initKeyEvent("keypress", true, false,
 				null,


### PR DESCRIPTION
Make the addon behave more like Opera 12 default behaviour. (delete selected text from address bar on Ctrl-B before pasting&going)
